### PR TITLE
Polish SoundCloud provider implementation 

### DIFF
--- a/docs/pages/providers/soundcloud.md
+++ b/docs/pages/providers/soundcloud.md
@@ -22,9 +22,9 @@ const soundcloud = new SoundCloud(clientId, clientSecret, redirectURI);
 import { generateState, createS256CodeChallenge } from "arctic";
 
 const state = generateState();
-const s256Challenge = createS256CodeChallenge();
+const codeVerifier = generateCodeVerifier();
 
-const url = soundcloud.createAuthorizationURL(state, s256Challenge);
+const url = soundcloud.createAuthorizationURL(state, codeVerifier);
 ```
 
 ## Validate authorization code

--- a/src/providers/soundcloud.ts
+++ b/src/providers/soundcloud.ts
@@ -1,3 +1,4 @@
+import { createS256CodeChallenge } from "../oauth2.js";
 import { createOAuth2Request, sendTokenRequest } from "../request.js";
 
 import { type OAuth2Tokens } from "../oauth2.js";
@@ -16,28 +17,27 @@ export class SoundCloud {
 		this.redirectURI = redirectURI;
 	}
 
-	public createAuthorizationURL(state: string, challenge: string): URL {
+	public createAuthorizationURL(state: string, codeVerifier: string): URL {
 		const url = new URL(authorizationEndpoint);
 		url.searchParams.set("client_id", this.clientId);
 		url.searchParams.set("redirect_uri", this.redirectURI);
 		url.searchParams.set("response_type", "code");
-		url.searchParams.set("code_challenge", challenge);
+		const codeChallenge = createS256CodeChallenge(codeVerifier);
+		url.searchParams.set("code_challenge", codeChallenge);
 		url.searchParams.set("code_challenge_method", "S256");
 		url.searchParams.set("state", state);
 		return url;
 	}
 
-	public async validateAuthorizationCode(code: string, challenge: string): Promise<OAuth2Tokens> {
+	public async validateAuthorizationCode(code: string, codeVerifier: string): Promise<OAuth2Tokens> {
 		const body = new URLSearchParams();
 		body.set("grant_type", "authorization_code");
 		body.set("client_id", this.clientId);
 		body.set("client_secret", this.clientSecret);
 		body.set("redirect_uri", this.redirectURI);
-		body.set("code_verifier", challenge);
+		body.set("code_verifier", codeVerifier);
 		body.set("code", code);
 		const request = createOAuth2Request(tokenEndpoint, body);
-		// const encodedCredentials = encodeBasicCredentials(this.clientId, this.clientSecret);
-		// request.headers.set("Authorization", `Basic ${encodedCredentials}`);
 		const tokens = await sendTokenRequest(request);
 		return tokens;
 	}
@@ -49,8 +49,6 @@ export class SoundCloud {
 		body.set("client_id", this.clientId);
 		body.set("client_secret", this.clientSecret);
 		const request = createOAuth2Request(tokenEndpoint, body);
-		// const encodedCredentials = encodeBasicCredentials(this.clientId, this.clientSecret);
-		// request.headers.set("Authorization", `Basic ${encodedCredentials}`);
 		const tokens = await sendTokenRequest(request);
 		return tokens;
 	}


### PR DESCRIPTION
I'm waiting on SoundCloud to allow new applications for API access and implementing other OAuth providers for my project. I came accross your PR and noticed that createS256CodeChallenge should be called from SoundCloud.createAuthorizationURL, per other S256 provider implementations (e.g. Zoom).